### PR TITLE
refactor: use latest Move

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -12,14 +12,14 @@ Movemate = "0xb2207be128ba3dd1de79c064495a7c97642a513d33d4313e686c33896a332f1a"
 [dependencies.MoveStdlib]
 git = "https://github.com/aptos-labs/aptos-core.git"
 subdir = "aptos-move/framework/move-stdlib"
-rev = "6538efd8bf4b37c61ec0427243e864ee038df5e8"
+rev = "a3143756d498821f4f51a5970c7ea35d483938b3"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
 subdir = "aptos-move/framework/aptos-framework"
-rev = "6538efd8bf4b37c61ec0427243e864ee038df5e8"
+rev = "a3143756d498821f4f51a5970c7ea35d483938b3"
 
 [dependencies.Econia]
 git = "https://github.com/econia-labs/econia.git"
 subdir = "src/move/econia"
-rev = "4a432c4da556d6916afa343e764086b4e2258b88"
+rev = "6a389ee8fd80ccd628ecbd994777113119ef0904"

--- a/sources/LinearVesting.move
+++ b/sources/LinearVesting.move
@@ -8,13 +8,13 @@
 /// Consequently, if the vesting has already started, any amount of tokens sent to this contract will (at least partly)
 /// be immediately releasable.
 module Movemate::LinearVesting {
-    use Std::Signer;
-    use Std::Vector;
+    use std::signer;
+    use std::vector;
 
-    use AptosFramework::Coin::{Self, Coin};
-    use AptosFramework::IterableTable::{Self, IterableTable};
-    use AptosFramework::Table::{Self, Table};
-    use AptosFramework::Timestamp;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::iterable_table::{Self, IterableTable};
+    use aptos_framework::table::{Self, Table};
+    use aptos_framework::timestamp;
 
     struct WalletInfo has store {
         start: u64,
@@ -38,28 +38,28 @@ module Movemate::LinearVesting {
     /// @dev Enables an asset on the admin's wallet collecton.
     public fun init_asset<T>(admin: &signer) {
         move_to(admin, CoinStoreCollection<T> {
-            wallets: IterableTable::new()
+            wallets: iterable_table::new()
         });
     }
 
     /// @dev Set the beneficiary, start timestamp and vesting duration of the vesting wallet.
     public fun init_wallet(admin: &signer, beneficiary: address, start_timestamp: u64, duration_seconds: u64, can_clawback: bool) acquires WalletInfoCollection {
         // Create WalletInfoCollection if it doesn't exist
-        let admin_address = Signer::address_of(admin);
+        let admin_address = signer::address_of(admin);
 
         if (!exists<WalletInfoCollection>(admin_address)) {
             move_to(admin, WalletInfoCollection {
-                wallets: IterableTable::new()
+                wallets: iterable_table::new()
             });
         };
 
         // Add beneficiary to collection
         let wallet_infos = &mut borrow_global_mut<WalletInfoCollection>(admin_address).wallets;
-        if (!IterableTable::contains(wallet_infos, beneficiary)) IterableTable::add(wallet_infos, beneficiary, Vector::empty());
-        let collection = IterableTable::borrow_mut(wallet_infos, beneficiary);
+        if (!iterable_table::contains(wallet_infos, beneficiary)) iterable_table::add(wallet_infos, beneficiary, vector::empty());
+        let collection = iterable_table::borrow_mut(wallet_infos, beneficiary);
 
         // Add wallet to array
-        Vector::push_back(collection, WalletInfo {
+        vector::push_back(collection, WalletInfo {
             start: start_timestamp,
             duration: duration_seconds,
             can_clawback
@@ -69,65 +69,65 @@ module Movemate::LinearVesting {
     /// @notice Returns the vesting wallet details.
     public fun wallet_info(admin: address, beneficiary: address, index: u64): (u64, u64, bool) acquires WalletInfoCollection {
         let wallet_infos = &mut borrow_global_mut<WalletInfoCollection>(admin).wallets;
-        let collection = IterableTable::borrow(wallet_infos, beneficiary);
-        let wallet_info = Vector::borrow(collection, index);
+        let collection = iterable_table::borrow(wallet_infos, beneficiary);
+        let wallet_info = vector::borrow(collection, index);
         (wallet_info.start, wallet_info.duration, wallet_info.can_clawback)
     }
 
     /// @notice Returns the vesting wallet asset balance and amount released.
     public fun wallet_asset<T>(admin: address, beneficiary: address, index: u64): (u64, u64) acquires CoinStoreCollection {
         let coin_stores = &borrow_global<CoinStoreCollection<T>>(admin).wallets;
-        let collection = IterableTable::borrow(coin_stores, beneficiary);
-        let coin_store = Table::borrow(collection, index);
-        (Coin::value(&coin_store.coin), coin_store.released)
+        let collection = iterable_table::borrow(coin_stores, beneficiary);
+        let coin_store = table::borrow(collection, index);
+        (coin::value(&coin_store.coin), coin_store.released)
     }
 
     /// @dev Release the tokens that have already vested.
     public fun release<T>(admin: address, beneficiary: address, index: u64) acquires WalletInfoCollection, CoinStoreCollection {
         // Get wallet info
         let wallet_infos = &borrow_global<WalletInfoCollection>(admin).wallets;
-        let collection = IterableTable::borrow(wallet_infos, beneficiary);
-        let wallet_info = Vector::borrow(collection, index);
+        let collection = iterable_table::borrow(wallet_infos, beneficiary);
+        let wallet_info = vector::borrow(collection, index);
 
         // Get coin store
         let coin_stores = &mut borrow_global_mut<CoinStoreCollection<T>>(admin).wallets;
-        let collection = IterableTable::borrow_mut(coin_stores, beneficiary);
-        let coin_store = Table::borrow_mut(collection, index);
+        let collection = iterable_table::borrow_mut(coin_stores, beneficiary);
+        let coin_store = table::borrow_mut(collection, index);
 
         // Release amount
-        let releasable = vested_amount(wallet_info.start, wallet_info.duration, Coin::value(&coin_store.coin), coin_store.released, Timestamp::now_seconds()) - coin_store.released;
+        let releasable = vested_amount(wallet_info.start, wallet_info.duration, coin::value(&coin_store.coin), coin_store.released, timestamp::now_seconds()) - coin_store.released;
         *&mut coin_store.released = *&coin_store.released + releasable;
-        let release_coin = Coin::extract(&mut coin_store.coin, releasable);
-        Coin::deposit(beneficiary, release_coin);
+        let release_coin = coin::extract(&mut coin_store.coin, releasable);
+        coin::deposit(beneficiary, release_coin);
     }
 
     /// @notice Claws back coins to the admin if `can_clawback` is enabled.
     public fun clawback<T>(admin: &signer, beneficiary: address, index: u64) acquires WalletInfoCollection, CoinStoreCollection {
         // Get admin address
-        let admin_address = Signer::address_of(admin);
+        let admin_address = signer::address_of(admin);
 
         // Get wallet info
         let wallet_infos = &borrow_global<WalletInfoCollection>(admin_address).wallets;
-        let collection = IterableTable::borrow(wallet_infos, beneficiary);
-        let wallet_info = Vector::borrow(collection, index);
+        let collection = iterable_table::borrow(wallet_infos, beneficiary);
+        let wallet_info = vector::borrow(collection, index);
 
         // Get coin store
         let coin_stores = &mut borrow_global_mut<CoinStoreCollection<T>>(admin_address).wallets;
-        let collection = IterableTable::borrow_mut(coin_stores, beneficiary);
-        let coin_store = Table::borrow_mut(collection, index);
+        let collection = iterable_table::borrow_mut(coin_stores, beneficiary);
+        let coin_store = table::borrow_mut(collection, index);
 
         // Release amount
-        let releasable = vested_amount(wallet_info.start, wallet_info.duration, Coin::value(&coin_store.coin), coin_store.released, Timestamp::now_seconds()) - coin_store.released;
+        let releasable = vested_amount(wallet_info.start, wallet_info.duration, coin::value(&coin_store.coin), coin_store.released, timestamp::now_seconds()) - coin_store.released;
         *&mut coin_store.released = *&coin_store.released + releasable;
-        let release_coin = Coin::extract(&mut coin_store.coin, releasable);
-        Coin::deposit(beneficiary, release_coin);
+        let release_coin = coin::extract(&mut coin_store.coin, releasable);
+        coin::deposit(beneficiary, release_coin);
 
         // Validate clawback
         assert!(wallet_info.can_clawback, 1000);
 
         // Execute clawback
-        let clawback_coin = Coin::extract_all(&mut coin_store.coin);
-        Coin::deposit<T>(admin_address, clawback_coin);
+        let clawback_coin = coin::extract_all(&mut coin_store.coin);
+        coin::deposit<T>(admin_address, clawback_coin);
     }
 
     /// Calculates the amount that has already vested. Default implementation is a linear vesting curve.

--- a/sources/Math.move
+++ b/sources/Math.move
@@ -47,7 +47,7 @@ module Movemate::Math {
     /// Inspired by Henry S. Warren, Jr.'s "Hacker's Delight" (Chapter 11).
     public fun sqrt(a: u64): u64 {
         if (a == 0) {
-            return 0;
+            return 0
         };
 
         // For our first guess, we get the biggest power of 2 which is smaller than the square root of the target.

--- a/sources/VirtualBlock.move
+++ b/sources/VirtualBlock.move
@@ -5,15 +5,15 @@
 /// Once you've created a new mempool (specifying a miner fee rate and a block time/delay), simply add entries to the block,
 /// mine the entries (for a miner fee), and repeat. Extract mempool fees as necessary.
 module Movemate::VirtualBlock {
-    use Std::Vector;
+    use std::vector;
 
-    use AptosFramework::Coin::{Self, Coin};
-    use AptosFramework::Timestamp;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::timestamp;
 
     use Econia::CritBit::{Self, CB};
 
     /// @notice Struct for a virtual block with entries sorted by bids.
-    struct Mempool<BidAssetType, EntryType> {
+    struct Mempool<phantom BidAssetType, EntryType> {
         blocks: vector<CB<EntryType>>,
         current_block_bids: Coin<BidAssetType>,
         last_block_timestamp: u64,
@@ -25,10 +25,10 @@ module Movemate::VirtualBlock {
     /// @notice Creates a new mempool (specifying miner fee rate and block time/delay).
     public fun new_mempool<BidAssetType, EntryType>(miner_fee_rate: u64, block_time: u64): Mempool<BidAssetType, EntryType> {
         Mempool<BidAssetType, EntryType> {
-            blocks: Vector::singleton<CB<EntryType>>(CritBit::empty<EntryType>()),
-            current_block_bids: Coin::zero<BidAssetType>(),
-            last_block_timestamp: Timestamp::now_microseconds(),
-            mempool_fees: Coin::zero<BidAssetType>(),
+            blocks: vector::singleton<CB<EntryType>>(CritBit::empty<EntryType>()),
+            current_block_bids: coin::zero<BidAssetType>(),
+            last_block_timestamp: timestamp::now_microseconds(),
+            mempool_fees: coin::zero<BidAssetType>(),
             miner_fee_rate,
             block_time
         }
@@ -36,38 +36,42 @@ module Movemate::VirtualBlock {
 
     /// @notice Extracts all fees accrued by a mempool.
     public fun extract_mempool_fees<BidAssetType, EntryType>(mempool: &mut Mempool<BidAssetType, EntryType>): Coin<BidAssetType> {
-        Coin::extract_all(&mut mempool.mempool_fees)
+        coin::extract_all(&mut mempool.mempool_fees)
     }
 
     /// @notice Adds an entry to the latest virtual block.
     public fun add_entry<BidAssetType, EntryType>(mempool: &mut Mempool<BidAssetType, EntryType>, entry: EntryType, bid: Coin<BidAssetType>) {
+        let coin_value = (coin::value(&bid) as u128);
+
         // Add bid to block
-        Coin::merge(&mut mempool.current_block_bids, bid);
+        coin::merge(&mut mempool.current_block_bids, bid);
+
+        let blocks_length = vector::length(&mempool.blocks);
 
         // Add entry to tree
-        let block = Vector::borrow_mut(&mut mempool.blocks, Vector::length(&mempool.blocks) - 1);
-        CritBit::insert(block, (Coin::value(&bid) as u128), entry);
+        let block = vector::borrow_mut(&mut mempool.blocks, blocks_length - 1);
+        CritBit::insert(block, coin_value, entry);
     }
 
     /// @notice Validates the block time and distributes fees.
     public fun mine_entries<BidAssetType, EntryType>(mempool: &mut Mempool<BidAssetType, EntryType>, miner: address): CB<EntryType> {
         // Validate time now >= last block time + block delay
-        let now = Timestamp::now_microseconds();
+        let now = timestamp::now_microseconds();
         assert!(now >= mempool.last_block_timestamp + mempool.block_time, 1000);
 
         // Withdraw miner_fee_rate / 2**16 to the miner
-        let miner_fee = Coin::value(&mempool.current_block_bids) * mempool.miner_fee_rate / (1 << 16);
-        Coin::deposit(miner, Coin::extract(&mut mempool.current_block_bids, miner_fee));
+        let miner_fee = coin::value(&mempool.current_block_bids) * mempool.miner_fee_rate / (1 << 16);
+        coin::deposit(miner, coin::extract(&mut mempool.current_block_bids, miner_fee));
 
         // Send the rest to the mempool admin
-        Coin::merge(&mut mempool.mempool_fees, Coin::extract_all(&mut mempool.current_block_bids));
+        coin::merge(&mut mempool.mempool_fees, coin::extract_all(&mut mempool.current_block_bids));
 
         // Get last block
-        let last_block = Vector::pop_back(&mut mempool.blocks);
+        let last_block = vector::pop_back(&mut mempool.blocks);
 
         // Create next block
-        Vector::push_back(&mut mempool.blocks, CritBit::empty<EntryType>());
-        *&mut mempool.last_block_timestamp = Timestamp::now_microseconds();
+        vector::push_back(&mut mempool.blocks, CritBit::empty<EntryType>());
+        *&mut mempool.last_block_timestamp = timestamp::now_microseconds();
 
         // Return entries of last block
         last_block


### PR DESCRIPTION
idk if you guys want these changes now, but I tried to build `movemate` with latest Move and Aptos CLIs
```console
➜  movemate git:(main) ✗ move --version    
move-cli 0.1.0
➜  movemate git:(main) ✗ aptos --version   
aptos 0.2.1

```

and it didn't work:
```console
➜  movemate git:(main) ✗ aptos move compile
{
  "Error": "Move compilation failed: Unable to resolve packages for package 'Movemate'"
}
```

I suppose it's due to `econia` depending on `origin/devnet` instead of exact commit of `AptosFramework` dependency:
```toml
[dependencies.AptosFramework]
git = 'https://github.com/aptos-labs/aptos-core'
subdir = 'aptos-move/framework/aptos-framework'
rev = 'origin/devnet'
```
(from https://github.com/econia-labs/econia/blob/4a432c4da556d6916afa343e764086b4e2258b88/src/move/econia/Move.toml#L15-L18)

---

So what changed is that recently `AptosFramework` underwent an update to newer Move version https://github.com/aptos-labs/aptos-core/pull/2018 which isn't compatible with older ones, and also their stdlib changed.

What I did here is very similar to https://github.com/econia-labs/econia/commit/0779280f0b9073772f3e7888209f9fa4acc1daad: just some syntax and stdlib changes without any change in logic.

It works now!
```console
➜  movemate git:(upgrade-move) ✗ aptos move compile
{
  "Result": [
    "B2207BE128BA3DD1DE79C064495A7C97642A513D33D4313E686C33896A332F1A::Governance",
    "B2207BE128BA3DD1DE79C064495A7C97642A513D33D4313E686C33896A332F1A::LinearVesting",
    "B2207BE128BA3DD1DE79C064495A7C97642A513D33D4313E686C33896A332F1A::Math",
    "B2207BE128BA3DD1DE79C064495A7C97642A513D33D4313E686C33896A332F1A::VirtualBlock"
  ]
}
```