### PR TITLE
Better clawbacks in `linear_vesting` and `quadratic_vesting`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,6 @@ Ideas and improvements.
 
 * `quadratic_vesting`: merge with `linear_vesting`?
 * `quadratic_vesting`: better tests.
-* `linear_vesting`: clawback capability.
 * `governance`: finish tests.
 * `merkle_proof`: unit tests for multi-proof verification.
 * `governance`: make delegation optional?

--- a/aptos/sources/linear_vesting.move
+++ b/aptos/sources/linear_vesting.move
@@ -9,6 +9,7 @@
 /// be immediately releasable.
 module movemate::linear_vesting {
     use std::error;
+    use std::option::{Self, Option};
     use std::signer;
     use std::vector;
 
@@ -24,7 +25,7 @@ module movemate::linear_vesting {
     struct WalletInfo has store {
         start: u64,
         duration: u64,
-        can_clawback: bool
+        clawbacker: Option<address>
     }
 
     struct WalletInfoCollection has key {
@@ -48,7 +49,7 @@ module movemate::linear_vesting {
     }
 
     /// @dev Set the beneficiary, start timestamp and vesting duration of the vesting wallet.
-    public entry fun init_wallet(admin: &signer, beneficiary: address, start_timestamp: u64, duration_seconds: u64, can_clawback: bool) acquires WalletInfoCollection {
+    public entry fun init_wallet(admin: &signer, beneficiary: address, start_timestamp: u64, duration_seconds: u64, clawbacker: Option<address>) acquires WalletInfoCollection {
         // Create WalletInfoCollection if it doesn't exist
         let admin_address = signer::address_of(admin);
 
@@ -67,7 +68,7 @@ module movemate::linear_vesting {
         vector::push_back(collection, WalletInfo {
             start: start_timestamp,
             duration: duration_seconds,
-            can_clawback
+            clawbacker
         });
     }
 
@@ -90,11 +91,11 @@ module movemate::linear_vesting {
     }
 
     /// @notice Returns the vesting wallet details.
-    public fun wallet_info(admin: address, beneficiary: address, index: u64): (u64, u64, bool) acquires WalletInfoCollection {
+    public fun wallet_info(admin: address, beneficiary: address, index: u64): (u64, u64, Option<address>) acquires WalletInfoCollection {
         let wallet_infos = &mut borrow_global_mut<WalletInfoCollection>(admin).wallets;
         let collection = iterable_table::borrow(wallet_infos, beneficiary);
         let wallet_info = vector::borrow(collection, index);
-        (wallet_info.start, wallet_info.duration, wallet_info.can_clawback)
+        (wallet_info.start, wallet_info.duration, wallet_info.clawbacker)
     }
 
     /// @notice Returns the vesting wallet asset balance and amount released.
@@ -124,18 +125,18 @@ module movemate::linear_vesting {
         coin::deposit(beneficiary, release_coin);
     }
 
-    /// @notice Claws back coins to the admin if `can_clawback` is enabled.
-    public entry fun clawback<T>(admin: &signer, beneficiary: address, index: u64) acquires WalletInfoCollection, CoinStoreCollection {
-        // Get admin address
-        let admin_address = signer::address_of(admin);
+    /// @notice Claws back coins to the admin if `clawbacker` is set.
+    public entry fun clawback<T>(clawbacker: &signer, admin: address, beneficiary: address, index: u64) acquires WalletInfoCollection, CoinStoreCollection {
+        // Get sender address
+        let sender = signer::address_of(clawbacker);
 
         // Get wallet info
-        let wallet_infos = &borrow_global<WalletInfoCollection>(admin_address).wallets;
+        let wallet_infos = &borrow_global<WalletInfoCollection>(admin).wallets;
         let collection = iterable_table::borrow(wallet_infos, beneficiary);
         let wallet_info = vector::borrow(collection, index);
 
         // Get coin store
-        let coin_stores = &mut borrow_global_mut<CoinStoreCollection<T>>(admin_address).wallets;
+        let coin_stores = &mut borrow_global_mut<CoinStoreCollection<T>>(admin).wallets;
         let collection = iterable_table::borrow_mut(coin_stores, beneficiary);
         let coin_store = table::borrow_mut(collection, index);
 
@@ -146,11 +147,28 @@ module movemate::linear_vesting {
         coin::deposit(beneficiary, release_coin);
 
         // Validate clawback
-        assert!(wallet_info.can_clawback, error::permission_denied(ECANNOT_CLAWBACK));
+        assert!(option::is_some(&wallet_info.clawbacker) && sender == *option::borrow(&wallet_info.clawbacker), error::permission_denied(ECANNOT_CLAWBACK));
 
         // Execute clawback
         let clawback_coin = coin::extract_all(&mut coin_store.coin);
-        coin::deposit<T>(admin_address, clawback_coin);
+        coin::deposit<T>(sender, clawback_coin);
+    }
+
+    /// @notice Changes the clawbacker for a vesting wallet.
+    public entry fun change_clawbacker<T>(clawbacker: &signer, admin: address, beneficiary: address, index: u64, new_clawbacker: Option<address>) acquires WalletInfoCollection {
+        // Get sender address
+        let sender = signer::address_of(clawbacker);
+
+        // Get wallet info
+        let wallet_infos = &mut borrow_global_mut<WalletInfoCollection>(admin).wallets;
+        let collection = iterable_table::borrow_mut(wallet_infos, beneficiary);
+        let wallet_info = vector::borrow_mut(collection, index);
+
+        // Validate clawback
+        assert!(option::is_some(&wallet_info.clawbacker) && sender == *option::borrow(&wallet_info.clawbacker), error::permission_denied(ECANNOT_CLAWBACK));
+
+        // Change clawbacker
+        *&mut wallet_info.clawbacker = new_clawbacker;
     }
 
     /// @dev Returns (1) the amount that has vested at the current time and the (2) portion of that amount that has not yet been released.
@@ -196,8 +214,8 @@ module movemate::linear_vesting {
         timestamp::update_global_time_for_test(timestamp::now_microseconds() + timestamp_seconds * 1000000);
     }
 
-    #[test(admin = @0x1000, beneficiary = @0x1001, coin_creator = @movemate, aptos_framework = @aptos_framework)]
-    public entry fun test_end_to_end(admin: signer, beneficiary: signer, coin_creator: signer, aptos_framework: signer) acquires WalletInfoCollection, CoinStoreCollection {
+    #[test(admin = @0x1000, beneficiary = @0x1001, clawbacker = @0x1002, coin_creator = @movemate, aptos_framework = @aptos_framework)]
+    public entry fun test_end_to_end(admin: signer, beneficiary: signer, clawbacker: signer, coin_creator: signer, aptos_framework: signer) acquires WalletInfoCollection, CoinStoreCollection {
         // start the clock
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
@@ -213,7 +231,8 @@ module movemate::linear_vesting {
 
         // init wallet and asset
         let beneficiary_address = signer::address_of(&beneficiary);
-        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, true);
+        let clawbacker_address = signer::address_of(&clawbacker);
+        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, option::some(clawbacker_address));
         init_asset<FakeMoney>(&admin);
         let admin_address = signer::address_of(&admin);
         deposit<FakeMoney>(admin_address, beneficiary_address, 0, coin_in);
@@ -226,10 +245,10 @@ module movemate::linear_vesting {
 
         // fast forward and claw back
         fast_forward_seconds(7200);
-        coin::register_for_test<FakeMoney>(&admin);
-        clawback<FakeMoney>(&admin, beneficiary_address, 0);
+        coin::register_for_test<FakeMoney>(&clawbacker);
+        clawback<FakeMoney>(&clawbacker, admin_address, beneficiary_address, 0);
         assert!(coin::balance<FakeMoney>(beneficiary_address) == 154320986, 1);
-        assert!(coin::balance<FakeMoney>(admin_address) == 1234567890 - 154320986, 2);
+        assert!(coin::balance<FakeMoney>(clawbacker_address) == 1234567890 - 154320986, 2);
 
         // clean up: we can't drop mint/burn caps so we store them
         move_to(&coin_creator, FakeMoneyCapabilities {
@@ -245,19 +264,19 @@ module movemate::linear_vesting {
 
         // init wallet and asset
         let beneficiary_address = signer::address_of(&beneficiary);
-        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, true);
+        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, option::none());
 
         // init wallet and asset
         let beneficiary2_address = signer::address_of(&beneficiary2);
-        init_wallet(&admin, beneficiary2_address, timestamp::now_seconds(), 86400, true);
+        init_wallet(&admin, beneficiary2_address, timestamp::now_seconds(), 86400, option::none());
 
         // init wallet and asset
-        init_wallet(&admin, beneficiary2_address, timestamp::now_seconds(), 172800, true);
+        init_wallet(&admin, beneficiary2_address, timestamp::now_seconds(), 172800, option::none());
     }
 
-    #[test(admin = @0x1000, beneficiary = @0x1001, coin_creator = @movemate, aptos_framework = @aptos_framework)]
+    #[test(admin = @0x1000, beneficiary = @0x1001, clawbacker = @0x1002, coin_creator = @movemate, aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x50000)]
-    public entry fun test_no_clawback(admin: signer, beneficiary: signer, coin_creator: signer, aptos_framework: signer) acquires WalletInfoCollection, CoinStoreCollection {
+    public entry fun test_no_clawback(admin: signer, beneficiary: signer, clawbacker: signer, coin_creator: signer, aptos_framework: signer) acquires WalletInfoCollection, CoinStoreCollection {
         // start the clock
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
@@ -273,7 +292,7 @@ module movemate::linear_vesting {
 
         // init wallet and asset
         let beneficiary_address = signer::address_of(&beneficiary);
-        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, false);
+        init_wallet(&admin, beneficiary_address, timestamp::now_seconds(), 86400, option::none());
         init_asset<FakeMoney>(&admin);
         let admin_address = signer::address_of(&admin);
         deposit<FakeMoney>(admin_address, beneficiary_address, 0, coin_in);
@@ -281,8 +300,8 @@ module movemate::linear_vesting {
         // fast forward and claw back (should fail)
         fast_forward_seconds(3600);
         coin::register_for_test<FakeMoney>(&beneficiary);
-        coin::register_for_test<FakeMoney>(&admin);
-        clawback<FakeMoney>(&admin, beneficiary_address, 0);
+        coin::register_for_test<FakeMoney>(&clawbacker);
+        clawback<FakeMoney>(&clawbacker, admin_address, beneficiary_address, 0);
 
         // clean up: we can't drop mint/burn caps so we store them
         move_to(&coin_creator, FakeMoneyCapabilities {

--- a/sui/sources/quadratic_vesting.move
+++ b/sui/sources/quadratic_vesting.move
@@ -12,7 +12,7 @@ module movemate::quadratic_vesting {
     use std::option::{Self, Option};
 
     use sui::coin::{Self, Coin};
-    use sui::object::{Self, Info};
+    use sui::object::{Self, ID, Info};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
@@ -20,8 +20,8 @@ module movemate::quadratic_vesting {
 
     const SCALAR: u64 = 1 << 16;
 
-    /// @dev When trying to clawback a wallet without the privilege to do so.
-    const ECANNOT_CLAWBACK: u64 = 0;
+    /// @dev When trying to clawback a wallet with the wrong wallet's capability.
+    const EWRONG_CLAWBACK_CAPABILITY: u64 = 0;
 
     struct Wallet<phantom T> has key {
         info: Info,
@@ -33,8 +33,12 @@ module movemate::quadratic_vesting {
         vesting_curve_c: u64,
         start: u64,
         cliff: u64,
-        duration: u64,
-        clawbacker: Option<address>
+        duration: u64
+    }
+
+    struct ClawbackCapability has key, store {
+        info: Info,
+        wallet_id: ID
     }
 
     /// @dev Set the beneficiary, start timestamp and vesting duration of the vesting wallet.
@@ -49,7 +53,7 @@ module movemate::quadratic_vesting {
         clawbacker: Option<address>,
         ctx: &mut TxContext
     ) {
-        transfer::share_object(Wallet<T> {
+        let wallet = Wallet<T> {
             info: object::new(ctx),
             beneficiary,
             coin: coin::zero<T>(ctx),
@@ -59,9 +63,38 @@ module movemate::quadratic_vesting {
             vesting_curve_c: curve_c,
             start,
             cliff,
-            duration,
-            clawbacker
-        });
+            duration
+        };
+        if (option::is_some(&clawbacker)) transfer::transfer(ClawbackCapability { info: object::new(ctx), wallet_id: *object::id(&wallet) }, option::destroy_some(clawbacker));
+        transfer::share_object(wallet);
+    }
+
+    /// @dev Set the beneficiary, start timestamp and vesting duration of the vesting wallet.
+    public fun init_wallet_return_clawback<T>(
+        beneficiary: address,
+        curve_a: u64,
+        curve_b: u64,
+        curve_c: u64,
+        start: u64,
+        cliff: u64,
+        duration: u64,
+        ctx: &mut TxContext
+    ): ClawbackCapability {
+        let wallet = Wallet<T> {
+            info: object::new(ctx),
+            beneficiary,
+            coin: coin::zero<T>(ctx),
+            released: 0,
+            vesting_curve_a: curve_a,
+            vesting_curve_b: curve_b,
+            vesting_curve_c: curve_c,
+            start,
+            cliff,
+            duration
+        };
+        let clawback_cap = ClawbackCapability { info: object::new(ctx), wallet_id: *object::id(&wallet) };
+        transfer::share_object(wallet);
+        clawback_cap
     }
 
     /// @dev Deposits `coin_in` to `wallet`.
@@ -70,8 +103,8 @@ module movemate::quadratic_vesting {
     }
 
     /// @notice Returns the vesting wallet details.
-    public fun wallet_info<T>(wallet: &mut Wallet<T>): (address, u64, u64, u64, u64, u64, u64, u64, u64, Option<address>) {
-        (wallet.beneficiary, coin::value(&wallet.coin), wallet.released, wallet.vesting_curve_a, wallet.vesting_curve_b, wallet.vesting_curve_c, wallet.start, wallet.cliff, wallet.duration, wallet.clawbacker)
+    public fun wallet_info<T>(wallet: &mut Wallet<T>): (address, u64, u64, u64, u64, u64, u64, u64, u64) {
+        (wallet.beneficiary, coin::value(&wallet.coin), wallet.released, wallet.vesting_curve_a, wallet.vesting_curve_b, wallet.vesting_curve_c, wallet.start, wallet.cliff, wallet.duration)
     }
 
     /// @dev Release the tokens that have already vested.
@@ -83,12 +116,15 @@ module movemate::quadratic_vesting {
     }
 
     /// @notice Claws back coins to the `clawbacker` if enabled.
-    /// @dev TODO: Clawback capability.
-    /// @dev TODO: Destroy wallet.
-    public entry fun clawback<T>(wallet: &mut Wallet<T>, ctx: &mut TxContext) {
-        // Check clawbacker address
-        let sender = tx_context::sender(ctx);
-        assert!(option::is_some(&wallet.clawbacker) && sender == *option::borrow(&wallet.clawbacker), errors::requires_address(ECANNOT_CLAWBACK));
+    /// @dev TODO: Possible to destroy shared wallet object?
+    public fun clawback<T>(wallet: &mut Wallet<T>, clawback_cap: ClawbackCapability, ctx: &mut TxContext): Coin<T> {
+        // Check and delete clawback capability
+        let ClawbackCapability {
+            info: info,
+            wallet_id: wallet_id
+        } = clawback_cap;
+        assert!(wallet_id == *object::id(wallet), errors::requires_capability(EWRONG_CLAWBACK_CAPABILITY));
+        object::delete(info);
 
         // Release amount
         let releasable = vested_amount(wallet.vesting_curve_a, wallet.vesting_curve_b, wallet.vesting_curve_c, wallet.start, wallet.cliff, wallet.duration, coin::value(&wallet.coin), wallet.released, tx_context::epoch(ctx)) - wallet.released;
@@ -98,7 +134,21 @@ module movemate::quadratic_vesting {
         // Execute clawback
         let coin_out = &mut wallet.coin;
         let value = coin::value(coin_out);
-        coin::split_and_transfer<T>(coin_out, value, sender, ctx);
+        coin::take<T>(coin::balance_mut(coin_out), value, ctx)
+    }
+
+    /// @notice Claws back coins to the `recipient` if enabled.
+    public entry fun clawback_to<T>(wallet: &mut Wallet<T>, clawback_cap: ClawbackCapability, recipient: address, ctx: &mut TxContext) {
+        coin::transfer(clawback(wallet, clawback_cap, ctx), recipient)
+    }
+
+    /// @dev Destroys a clawback capability.
+    public fun destroy_clawback_capability(clawback_cap: ClawbackCapability) {
+        let ClawbackCapability {
+            info: info,
+            wallet_id: _
+        } = clawback_cap;
+        object::delete(info);
     }
 
     /// @dev Returns (1) the amount that has vested at the current time and the (2) portion of that amount that has not yet been released.
@@ -178,7 +228,8 @@ module movemate::quadratic_vesting {
         test_scenario::next_epoch(scenario);
         let wallet_wrapper = test_scenario::take_shared<Wallet<FakeMoney>>(scenario);
         let wallet = test_scenario::borrow_mut(&mut wallet_wrapper);
-        clawback<FakeMoney>(wallet, test_scenario::ctx(scenario));
+        let clawback_cap = test_scenario::take_owned<ClawbackCapability>(scenario);
+        clawback_to<FakeMoney>(wallet, clawback_cap, TEST_ADMIN_ADDR, test_scenario::ctx(scenario));
         test_scenario::return_shared(scenario, wallet_wrapper);
 
         // Ensure clawback worked as planned
@@ -193,7 +244,6 @@ module movemate::quadratic_vesting {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0x002)]
     public entry fun test_no_clawback() {
         // Test scenario
         let scenario = &mut test_scenario::begin(&TEST_ADMIN_ADDR);
@@ -211,7 +261,7 @@ module movemate::quadratic_vesting {
         // fast forward and claw back (should fail)
         test_scenario::next_epoch(scenario);
         test_scenario::next_epoch(scenario);
-        clawback<FakeMoney>(wallet, test_scenario::ctx(scenario));
+        assert!(!test_scenario::can_take_owned<ClawbackCapability>(scenario), 0);
 
         // clean up: return shared wallet object
         test_scenario::return_shared(scenario, wallet_wrapper);


### PR DESCRIPTION
- On Aptos: allow changing the authorized clawbacker address.
- On Sui: use clawback capabilities instead of an authorized address.